### PR TITLE
chore: add loki

### DIFF
--- a/helm/fmtok8s-conference-chart/Chart.yaml
+++ b/helm/fmtok8s-conference-chart/Chart.yaml
@@ -37,3 +37,7 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.6.4
   condition: grafana.enabled
+- name: bitnami/grafana-loki
+  repository: https://charts.bitnami.com/bitnami
+  version: 2.3.2
+  condition: loki.enabled

--- a/helm/fmtok8s-conference-chart/templates/loki-datasource.yaml
+++ b/helm/fmtok8s-conference-chart/templates/loki-datasource.yaml
@@ -11,7 +11,7 @@ spec:
     - name: Loki
       type: loki
       access: proxy
-      url: {{ .Release.Name }}-grafana-loki-gateway:3100
+      url: {{ .Release.Name }}-grafana-loki-gateway
       isDefault: false
       version: 1
       editable: true

--- a/helm/fmtok8s-conference-chart/templates/loki-datasource.yaml
+++ b/helm/fmtok8s-conference-chart/templates/loki-datasource.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     
 spec:
-  name: middleware.yaml
+  name: grafana-loki.yaml
   datasources:
     - name: Loki
       type: loki

--- a/helm/fmtok8s-conference-chart/templates/loki-datasource.yaml
+++ b/helm/fmtok8s-conference-chart/templates/loki-datasource.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.loki.enabled }}
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDataSource
+metadata:
+  name: loki-datasource
+  labels:
+    
+spec:
+  name: middleware.yaml
+  datasources:
+    - name: Loki
+      type: loki
+      access: proxy
+      url: {{ .Release.Name }}-grafana-loki-gateway:3100
+      isDefault: false
+      version: 1
+      editable: true
+{{- end }}


### PR DESCRIPTION
This PR adds:
- Add`bitnami/grafana-loki` to chart's dependencies 
-  Add new GrafanaDatasource resource (loki-datasource) with condition - value `loki.enabled` is `true`.